### PR TITLE
Use https instead of http

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
-var getJson=require('load-json')
-var BASE_URL='http://kat.cr'
+var request=require('request');
+var BASE_URL='https://kat.cr';
 
 /**
  * {String|Object} query string or options f.x {}
@@ -8,14 +8,23 @@ var BASE_URL='http://kat.cr'
  * http://kickass.to/json.php?q=test&field=seeders&order=desc&page=2
  */
 module.exports=function(options, callback){
-    if(typeof options==='string')
-        options={q: options}
-    if(!options.q)
-        return callback(new Error('Search term "q" must be defined'))
     var url=(options.url || BASE_URL) + '/json.php';
-    getJson(url, options, function(e, response){
-        if(e)
-            return callback(e)
-        callback(null, response)
-    })
+
+    options.url = null;
+    var params = {
+      qs: options,
+      url: url
+    };
+
+    request(params, function(err, response, raw){
+      if(err) { return callback(err, null); }
+
+      try {
+        var data = JSON.parse(raw);
+      } catch(err) {
+        return callback(err, null);
+      }
+
+      callback(null, data);
+    });
 }

--- a/index.js
+++ b/index.js
@@ -12,19 +12,19 @@ module.exports=function(options, callback){
 
     options.url = null;
     var params = {
-      qs: options,
-      url: url
+        qs: options,
+        url: url
     };
 
     request(params, function(err, response, raw){
-      if(err) { return callback(err, null); }
+        if(err) { return callback(err, null); }
 
-      try {
+        try {
         var data = JSON.parse(raw);
-      } catch(err) {
+        } catch(err) {
         return callback(err, null);
-      }
+        }
 
-      callback(null, data);
+        callback(null, data);
     });
 }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,6 @@
   },
   "homepage": "https://github.com/gusnips/node-kickass-torrent",
   "dependencies": {
-    "load-json": "*"
+    "request": "*"
   }
 }

--- a/spec/kickassSpecs.js
+++ b/spec/kickassSpecs.js
@@ -31,8 +31,8 @@ describe('kickass', function(){
         })
     });
 
-    it("should return an empty list", function(done) {
-        params.q = "3d8f7c6e91bbaa6766948ec13320533f"
+    it('should return an empty list', function(done) {
+        params.q = '3d8f7c6e91bbaa6766948ec13320533f';
         kickass(params, function(err, result) {
             expect(err).toBeNull();
             expect(result.list.length).toBe(0);

--- a/spec/kickassSpecs.js
+++ b/spec/kickassSpecs.js
@@ -1,0 +1,42 @@
+var kickass = require('../index');
+
+var params = {
+  q: 'test',
+  field:'seeders',
+  order:'desc'
+}
+
+describe('kickass', function(){
+    it('should contain an array of torrents', function(done) {
+        kickass(params, function(err, result) {
+            expect(err).toBeNull();
+            expect(result.list.length).not.toBe(0);
+            result.list.forEach(function(element) {
+                expect(element.title).not.toBeNull();
+                expect(element.link).not.toBeNull();
+                expect(element.guid).not.toBeNull();
+                expect(element.pubDate).not.toBeNull();
+                expect(element.torrentLink).not.toBeNull();
+                expect(element.files).not.toBeNull();
+                expect(element.comments).not.toBeNull();
+                expect(element.hash).not.toBeNull();
+                expect(element.peers).not.toBeNull();
+                expect(element.seeds).not.toBeNull();
+                expect(element.leechs).not.toBeNull();
+                expect(element.size).toBeGreaterThan(0);
+                expect(element.votes).not.toBeNull();
+                expect(element.verified).not.toBeNull();
+            })
+            done();
+        })
+    });
+
+    it("should return an empty list", function(done) {
+        params.q = "3d8f7c6e91bbaa6766948ec13320533f"
+        kickass(params, function(err, result) {
+            expect(err).toBeNull();
+            expect(result.list.length).toBe(0);
+            done();
+        });
+    })
+});


### PR DESCRIPTION
`http://kat.cr` (without https) is currently redirecting to `https://kat.cr`. I've updated the implementation accordingly without changing the public API. I've also added some specs to verify my implementation. 

You need `jasmine-node` to run the specs, which you can install using `npm install jasmine-node -g`. You can then run the specs using `jasmine-node spec/kickassSpecs.js --matchall`.
